### PR TITLE
improve providers

### DIFF
--- a/provider/native.go
+++ b/provider/native.go
@@ -27,6 +27,10 @@ func newNativeURIParser(content string) ([]option.Outbound, error) {
 		)
 		protocol := strings.ToLower(trimBlank(parsedArr[1]))
 		parsedProxy := trimBlank(decodeBase64Safe(trimBlank(parsedArr[2])))
+		if json.Valid([]byte(parsedProxy)) {
+			re := regexp.MustCompile(`(\"\b\w+\b\"):([^,\}\"]+)`)
+			parsedProxy = re.ReplaceAllString(parsedProxy, `$1:"$2"`)
+		}
 		switch protocol {
 		case "ss":
 			outbound, err = newSSNativeParser(parsedProxy)


### PR DESCRIPTION
When the subscribed JSON is not standardized (Bool and Int have no quotes), providers will ignore it.
My original intention was to give you feedback, but I couldn't find a channel, so I submitted this Pull.

当订阅的JSON不规范的时候（Bool和Int没有引号），providers会忽略它。
我的本意是想反馈给您，但找不到渠道，所以就提交了这个Pull。