### PR TITLE
fix newVLESSNativeParser

### DIFF
--- a/provider/native.go
+++ b/provider/native.go
@@ -432,7 +432,8 @@ func newVLESSNativeParser(content string) (option.Outbound, error) {
 	for key, value := range proxy {
 		switch key {
 		case "type":
-			Transport := option.V2RayTransportOptions{
+			var Transport *option.V2RayTransportOptions
+			Transport = &option.V2RayTransportOptions{
 				Type: "",
 				WebsocketOptions: option.V2RayWebsocketOptions{
 					Headers: map[string]option.Listable[string]{},
@@ -482,8 +483,10 @@ func newVLESSNativeParser(content string) (option.Outbound, error) {
 				if serviceName, exists := proxy["serviceName"]; exists && serviceName != "" {
 					Transport.GRPCOptions.ServiceName = serviceName
 				}
+			default:
+				Transport = nil
 			}
-			options.Transport = &Transport
+			options.Transport = Transport
 		case "security":
 			if value == "tls" {
 				TLSOptions.Enabled = true


### PR DESCRIPTION
修复vless协议链接解析时的问题。
问题描述：当vless链接中的传输方式为tcp时，switch case 不可以匹配到结果，此时赋值给`options.Transport`会导致解析失败，返回空字符。
修复方法：给switch case增加一个默认条件，`Transport = nil`即可